### PR TITLE
Add dynamic metric entity

### DIFF
--- a/libs/core-infrastructure/src/database/database.module.ts
+++ b/libs/core-infrastructure/src/database/database.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { EventOrmEntity } from './entities/event.orm-entity';
 import { MetricOrmEntity } from './entities/metric.orm-entity';
+import { DynamicMetricOrmEntity } from './entities/dynamic-metric.orm-entity';
 import { EventRepository } from './repositories/event.repository';
 import { MetricRepository } from './repositories/metric.repository';
 import { RedisService } from '../redis/redis.service';
@@ -19,7 +20,7 @@ import { MetricsRepository } from './repositories/metrics.repository';
       autoLoadEntities: true,
       synchronize: true, // ¡Quita esto en producción!
     }),
-    TypeOrmModule.forFeature([EventOrmEntity, MetricOrmEntity]),
+    TypeOrmModule.forFeature([EventOrmEntity, MetricOrmEntity, DynamicMetricOrmEntity]),
   ],
   providers: [EventRepository, MetricRepository, MetricsRepository, RedisService],
   exports: [EventRepository, MetricRepository, MetricsRepository, RedisService],

--- a/libs/core-infrastructure/src/database/entities/dynamic-metric.orm-entity.ts
+++ b/libs/core-infrastructure/src/database/entities/dynamic-metric.orm-entity.ts
@@ -1,0 +1,32 @@
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity('dynamic_metrics')
+export class DynamicMetricOrmEntity {
+  @PrimaryGeneratedColumn('uuid')
+    id!: string;
+
+  @Column({ unique: true })
+    name!: string;
+
+  @Column()
+    type!: string;
+
+  @Column()
+    eventType!: string;
+
+  @Column()
+    period!: string;
+
+  @Column()
+    field!: string;
+
+  @Column('jsonb', { nullable: true })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    filters!: Record<string, any>;
+
+  @CreateDateColumn()
+    createdAt!: Date;
+
+  @UpdateDateColumn()
+    updatedAt!: Date;
+}


### PR DESCRIPTION
## Summary
- add DynamicMetricOrmEntity to track dynamic metric definitions
- register new entity in DatabaseModule

## Testing
- `nx run-many --target=test --all` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687b8826203c8332ada2cd367c7f368a