### PR TITLE
Add DynamicMetric repository

### DIFF
--- a/libs/core-infrastructure/src/database/database.module.ts
+++ b/libs/core-infrastructure/src/database/database.module.ts
@@ -4,8 +4,10 @@ import { EventOrmEntity } from './entities/event.orm-entity';
 import { MetricOrmEntity } from './entities/metric.orm-entity';
 import { EventRepository } from './repositories/event.repository';
 import { MetricRepository } from './repositories/metric.repository';
+import { DynamicMetricRepository } from './repositories/dynamic-metric.repository';
 import { RedisService } from '../redis/redis.service';
 import { MetricsRepository } from './repositories/metrics.repository';
+import { DynamicMetricOrmEntity } from './entities/dynamic-metric.orm-entity';
 
 @Module({
   imports: [
@@ -19,9 +21,9 @@ import { MetricsRepository } from './repositories/metrics.repository';
       autoLoadEntities: true,
       synchronize: true, // ¡Quita esto en producción!
     }),
-    TypeOrmModule.forFeature([EventOrmEntity, MetricOrmEntity]),
+    TypeOrmModule.forFeature([EventOrmEntity, MetricOrmEntity, DynamicMetricOrmEntity]),
   ],
-  providers: [EventRepository, MetricRepository, MetricsRepository, RedisService],
-  exports: [EventRepository, MetricRepository, MetricsRepository, RedisService],
+  providers: [EventRepository, MetricRepository, DynamicMetricRepository, MetricsRepository, RedisService],
+  exports: [EventRepository, MetricRepository, DynamicMetricRepository, MetricsRepository, RedisService],
 })
 export class DatabaseModule {}

--- a/libs/core-infrastructure/src/database/entities/dynamic-metric.orm-entity.ts
+++ b/libs/core-infrastructure/src/database/entities/dynamic-metric.orm-entity.ts
@@ -1,0 +1,20 @@
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity('dynamic_metrics')
+export class DynamicMetricOrmEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ unique: true })
+  name!: string;
+
+  @Column('jsonb', { nullable: true })
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  config!: Record<string, any>;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/libs/core-infrastructure/src/database/repositories/dynamic-metric.repository.ts
+++ b/libs/core-infrastructure/src/database/repositories/dynamic-metric.repository.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { DynamicMetricDto } from '@metrics-platform/core-shared';
+import { DynamicMetricOrmEntity } from '../entities/dynamic-metric.orm-entity';
+
+@Injectable()
+export class DynamicMetricRepository {
+  constructor(
+    @InjectRepository(DynamicMetricOrmEntity)
+    private readonly repo: Repository<DynamicMetricOrmEntity>
+  ) {}
+
+  async create(metric: DynamicMetricDto): Promise<DynamicMetricOrmEntity> {
+    return this.repo.save(metric);
+  }
+
+  async update(id: string, dto: Partial<DynamicMetricDto>): Promise<DynamicMetricOrmEntity | null> {
+    await this.repo.update(id, dto);
+    return this.repo.findOne({ where: { id } });
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.repo.delete(id);
+  }
+
+  async findByName(name: string): Promise<DynamicMetricOrmEntity | null> {
+    return this.repo.findOne({ where: { name } });
+  }
+
+  async findAll(): Promise<DynamicMetricOrmEntity[]> {
+    return this.repo.find();
+  }
+}

--- a/libs/core-infrastructure/src/index.ts
+++ b/libs/core-infrastructure/src/index.ts
@@ -2,6 +2,7 @@ export * from './database/database.module';
 export * from './database/repositories/event.repository';
 export * from './database/repositories/metric.repository';
 export * from './database/repositories/metrics.repository';
+export * from './database/repositories/dynamic-metric.repository';
 
 export * from './queues/queue.module';
 

--- a/libs/core-shared/src/dto/dynamic-metric.dto.ts
+++ b/libs/core-shared/src/dto/dynamic-metric.dto.ts
@@ -1,0 +1,5 @@
+export class DynamicMetricDto {
+  name!: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  config?: Record<string, any>;
+}

--- a/libs/core-shared/src/index.ts
+++ b/libs/core-shared/src/index.ts
@@ -1,5 +1,6 @@
 export * from './dto/create-event.dto';
 export * from './dto/create-metric.dto';
+export * from './dto/dynamic-metric.dto';
 
 export * from './interfaces/event-payload.interface';
 export * from './interfaces/metric-result.interface';


### PR DESCRIPTION
## Summary
- add `DynamicMetricDto` and export it
- add `DynamicMetricOrmEntity` model
- implement `DynamicMetricRepository` with CRUD operations
- register repository & entity in `DatabaseModule`
- export repository from `core-infrastructure`

## Testing
- `npx nx lint core-infrastructure` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npx nx test core-infrastructure` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_687b8849ddec8332908335132d40ad6b