### PR TITLE
Add dynamic metric query builder

### DIFF
--- a/libs/core-application/src/index.ts
+++ b/libs/core-application/src/index.ts
@@ -16,5 +16,7 @@ export * from './events/metric-calculated.event';
 
 export * from './use-cases/calculate-metrics.use-case';
 
+export * from './services/dynamic-metric-query.service';
+
 
 export * from './lib/core-application.module';

--- a/libs/core-application/src/services/dynamic-metric-query.service.spec.ts
+++ b/libs/core-application/src/services/dynamic-metric-query.service.spec.ts
@@ -1,0 +1,37 @@
+import { DynamicMetricQueryService, DynamicMetricEntity } from './dynamic-metric-query.service';
+import { DataSource } from 'typeorm';
+
+describe('DynamicMetricQueryService', () => {
+  let service: DynamicMetricQueryService;
+  let dataSource: { query: jest.Mock } as unknown as DataSource;
+
+  beforeEach(() => {
+    dataSource = { query: jest.fn() } as any;
+    service = new DynamicMetricQueryService(dataSource as unknown as DataSource);
+  });
+
+  it('builds query with parameters', () => {
+    const def: DynamicMetricEntity = {
+      table: 'events',
+      aggregation: { field: 'amount', func: 'sum', alias: 'total' },
+      conditions: [
+        { column: 'user_id', operator: '=', paramKey: 'userId' },
+        { column: 'created_at', operator: '>=', paramKey: 'from' },
+      ],
+    };
+    const { sql, values } = service.buildQuery(def, { userId: 5, from: '2024-01-01' });
+    expect(sql).toBe('SELECT SUM(amount) AS total FROM events WHERE user_id = $1 AND created_at >= $2');
+    expect(values).toEqual([5, '2024-01-01']);
+  });
+
+  it('executes built query', async () => {
+    const def: DynamicMetricEntity = {
+      table: 'events',
+      aggregation: { field: '*', func: 'count', alias: 'c' },
+    };
+    (dataSource.query as jest.Mock).mockResolvedValueOnce([{ c: 3 }]);
+    const result = await service.execute(def, {});
+    expect(result).toEqual([{ c: 3 }]);
+    expect(dataSource.query).toHaveBeenCalledWith('SELECT COUNT(*) AS c FROM events', []);
+  });
+});

--- a/libs/core-application/src/services/dynamic-metric-query.service.ts
+++ b/libs/core-application/src/services/dynamic-metric-query.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+
+export type AggregationFn = 'sum' | 'count' | 'avg';
+
+export interface MetricCondition {
+  column: string;
+  operator: '=' | '!=' | '>' | '>=' | '<' | '<=' | 'LIKE';
+  paramKey: string;
+}
+
+export interface DynamicMetricEntity {
+  table: string;
+  aggregation: {
+    field: string;
+    func: AggregationFn;
+    alias?: string;
+  };
+  conditions?: MetricCondition[];
+}
+
+@Injectable()
+export class DynamicMetricQueryService {
+  constructor(private readonly dataSource: DataSource) {}
+
+  buildQuery(definition: DynamicMetricEntity, params: Record<string, any>) {
+    const agg = `${definition.aggregation.func.toUpperCase()}(${definition.aggregation.field})`;
+    const alias = definition.aggregation.alias ?? 'value';
+    let sql = `SELECT ${agg} AS ${alias} FROM ${definition.table}`;
+
+    const values: any[] = [];
+    const where: string[] = [];
+    for (const cond of definition.conditions ?? []) {
+      if (Object.prototype.hasOwnProperty.call(params, cond.paramKey)) {
+        values.push(params[cond.paramKey]);
+        where.push(`${cond.column} ${cond.operator} $${values.length}`);
+      }
+    }
+
+    if (where.length) {
+      sql += ` WHERE ${where.join(' AND ')}`;
+    }
+
+    return { sql, values };
+  }
+
+  async execute(definition: DynamicMetricEntity, params: Record<string, any>) {
+    const { sql, values } = this.buildQuery(definition, params);
+    return this.dataSource.query(sql, values);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `DynamicMetricQueryService` for building and executing ad‑hoc metric queries
- expose new service from `core-application`
- provide unit tests covering query generation and execution

## Testing
- `npx nx test core-application` *(fails: 403 Forbidden fetching nx)*

------
https://chatgpt.com/codex/tasks/task_e_687b88a06a2c8332a70d7d3146df6f4b